### PR TITLE
feat: add get_token login in BaseConnector

### DIFF
--- a/src/plugin/connector/base.py
+++ b/src/plugin/connector/base.py
@@ -1,3 +1,6 @@
+import json
+
+import requests
 from spaceone.core.connector import BaseConnector
 
 
@@ -5,3 +8,19 @@ class NHNCloudBaseConnector(BaseConnector):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def get_token(secret_data: dict) -> dict:
+        params = {
+            "auth": {
+                "tenantId": secret_data.get('tenant_id'),
+                "passwordCredentials": {
+                    "username": secret_data.get('username'),
+                    "password": secret_data.get('password')
+                }
+            }
+        }
+        response = requests.post("https://api-identity-infrastructure.nhncloudservice.com/v2.0/tokens", json=params)
+        response_dict = json.loads(response.content)
+        token = response_dict['access']['token']['id']
+        return token


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
Add base connector for get_token logic in common
The connector for each CloudServiceType will be inherited and extends BaseConnector.

### Known issue
resolve #7 