### PR TITLE
Ignore collecting dns when the service is inactivated

### DIFF
--- a/src/plugin/connector/dns_plus/dns_zone_connector.py
+++ b/src/plugin/connector/dns_plus/dns_zone_connector.py
@@ -21,6 +21,10 @@ class DNSZoneConnector(NHNCloudBaseConnector):
                                     })
 
             if response.status_code != 200 or response.json().get('header').get('isSuccessful') is False:
+                # Ignore collecting request when the service is inactivated. This logic does not ensure that app key is valid.
+                if response.json().get('header').get('resultCode') == 4010001:
+                    return []
+
                 _LOGGER.error(f"Failed to get zones. {response.json()}")
                 raise Exception(f"Failed to get zones. {response.json()}")
 

--- a/src/plugin/connector/dns_plus/gslb_connector.py
+++ b/src/plugin/connector/dns_plus/gslb_connector.py
@@ -21,6 +21,10 @@ class GSLBConnector(NHNCloudBaseConnector):
                                     })
 
             if response.status_code != 200 or response.json().get('header').get('isSuccessful') is False:
+                # Ignore collecting request when the service is inactivated. This logic does not ensure that app key is valid.
+                if response.json().get('header').get('resultCode') == 4010001:
+                    return []
+
                 _LOGGER.error(f"Failed to get GSLBs. {response.json()}")
                 raise Exception(f"Failed to get GSLBs. {response.json()}")
 

--- a/src/plugin/connector/dns_plus/health_check_connector.py
+++ b/src/plugin/connector/dns_plus/health_check_connector.py
@@ -21,6 +21,10 @@ class HealthCheckConnector(NHNCloudBaseConnector):
                                     })
 
             if response.status_code != 200 or response.json().get('header').get('isSuccessful') is False:
+                # Ignore collecting request when the service is inactivated. This logic does not ensure that app key is valid.
+                if response.json().get('header').get('resultCode') == 4010001:
+                    return []
+
                 _LOGGER.error(f"Failed to get Health Checks. {response.json()}")
                 raise Exception(f"Failed to get Health Checks. {response.json()}")
 

--- a/src/plugin/connector/dns_plus/pool_connector.py
+++ b/src/plugin/connector/dns_plus/pool_connector.py
@@ -21,6 +21,10 @@ class PoolConnector(NHNCloudBaseConnector):
                                     })
 
             if response.status_code != 200 or response.json().get('header').get('isSuccessful') is False:
+                # Ignore collecting request when the service is inactivated. This logic does not ensure that app key is valid.
+                if response.json().get('header').get('resultCode') == 4010001:
+                    return []
+
                 _LOGGER.error(f"Failed to get pools. {response.json()}")
                 raise Exception(f"Failed to get pools. {response.json()}")
 


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description

- Because we cannot distinguish between a service being disabled and an invalid AppKey, plugin have to ignore when it request with invalid appkey.

### Known issue