### PR TITLE
Detache certificate service account from app key sa

### DIFF
--- a/managed_resource/schema/nhncloud_certificate_manager_app_key.yaml
+++ b/managed_resource/schema/nhncloud_certificate_manager_app_key.yaml
@@ -1,26 +1,16 @@
 ---
-schema_id: nhncloud-app-key
-name: NHN Cloud App Key
+schema_id: nhncloud-certificate-manager-app-key
+name: NHN Cloud Certificate Manager App Key
 schema_type: SECRET
 schema:
   order:
-  - app_key
-  - email_secret_key
-  - push_secret_key
+  - certificate_manager_app_key
   - user_access_key_id
   - secret_access_key
   properties:
-    app_key:
+    certificate_manager_app_key:
       format: password
-      title: APP Key
-      type: string
-    email_secret_key:
-      format: password
-      title: Email Secret Key
-      type: string
-    push_secret_key:
-      format: password
-      title: Push Secret Key
+      title: Certificate Manager APP Key
       type: string
     user_access_key_id:
       format: password
@@ -31,6 +21,8 @@ schema:
       title: Secret Access Key
       type: string
   required:
-  - app_key
+  - certificate_manager_app_key
+  - user_access_key_id
+  - secret_access_key
   type: object
 provider: nhncloud

--- a/managed_resource/schema/nhncloud_service_account.yaml
+++ b/managed_resource/schema/nhncloud_service_account.yaml
@@ -14,3 +14,4 @@ provider: nhncloud
 related_schemas:
   - nhncloud-access-key
   - nhncloud-app-key
+  - nhncloud-certificate-manager-app-key

--- a/src/plugin/conf/cloud_service_conf.py
+++ b/src/plugin/conf/cloud_service_conf.py
@@ -3,6 +3,7 @@ from enum import Enum
 class AUTH_TYPE(Enum):
     TOKEN = "nhncloud-access-key"
     APP_KEY = "nhncloud-app-key"
+    CERTIFICATE_MANAGER_APP_KEY = "nhncloud-certificate-manager-app-key"
 
 ASSET_URL="https://raw.githubusercontent.com/cloudforet-io/static-assets/master/providers/nhncloud"
 PROVIDER_NAME="nhncloud"

--- a/src/plugin/manager/base.py
+++ b/src/plugin/manager/base.py
@@ -48,6 +48,8 @@ class NHNCloudBaseManager(BaseManager):
             return AUTH_TYPE.TOKEN
         if 'app_key' in secret_data:
             return AUTH_TYPE.APP_KEY
+        if 'certificate_manager_app_key' in secret_data and 'user_access_key_id' in secret_data and 'secret_access_key' in secret_data:
+            return AUTH_TYPE.CERTIFICATE_MANAGER_APP_KEY
 
         raise NotImplementedError("Secret data is not valid")
 

--- a/src/plugin/manager/certificate_manager/certificate_manager.py
+++ b/src/plugin/manager/certificate_manager/certificate_manager.py
@@ -9,7 +9,7 @@ _LOGGER = logging.getLogger("cloudforet")
 
 
 class CertificateManager(NHNCloudBaseManager):
-    auth_type = AUTH_TYPE.APP_KEY
+    auth_type = AUTH_TYPE.CERTIFICATE_MANAGER_APP_KEY
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -35,12 +35,7 @@ class CertificateManager(NHNCloudBaseManager):
 
     def create_cloud_service(self, secret_data):
         certificate_connector = CertificateConnector()
-        certificates = []
-
-        if (secret_data.get("certificate_app_key") is not None and 
-            secret_data.get("user_access_key_id") is not None and 
-            secret_data.get("secret_access_key") is not None):
-            certificates = certificate_connector.list_certificates(secret_data.get("certificate_app_key"), secret_data.get("user_access_key_id"), secret_data.get("secret_access_key"))
+        certificates = certificate_connector.list_certificates(secret_data.get("certificate_manager_app_key"), secret_data.get("user_access_key_id"), secret_data.get("secret_access_key"))
 
         for certificate in certificates:
             reference = {


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description

- Because certificate manager api use independent auth info, it has to detach from the app key service account.

### Known issue