### PR TITLE
Add storage size column in block storage

### DIFF
--- a/src/plugin/manager/block_storage/block_storage_manager.py
+++ b/src/plugin/manager/block_storage/block_storage_manager.py
@@ -65,6 +65,7 @@ class BlockStorageManager(NHNCloudBaseManager):
                     data=resource,
                     account=secret_data.get("username", None),
                     reference=reference,
-                    region_code=AVAILABLE_REGION.name
+                    region_code=AVAILABLE_REGION.name,
+                    instance_size=resource.get("size", 0) * (1024 ** 3)
                 )
                 yield cloud_service


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
storage size column to display size (with GB to byte converting)
### Known issue